### PR TITLE
Fix timeline chart date labels

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+### Fix — Timeline chart date labels are concise and locale-aware
+
+- Format timeline X-axis ticks as abbreviated month and day values in the active UI locale instead of displaying the native JavaScript `Date.toString()` value with time and timezone details. Calendar-date values are formatted in UTC so users west of UTC do not see the previous day.
+
 ### Security — Second Holmes CSR pass: KMS region scoping, path traversal, log hygiene
 
 Ran a follow-up Holmes CSR scan after the fixes below. Findings and fixes:

--- a/frontend/src/components/TimelineChart.test.tsx
+++ b/frontend/src/components/TimelineChart.test.tsx
@@ -1,0 +1,66 @@
+import { render } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import LineChart from '@cloudscape-design/components/line-chart';
+import { I18nProvider } from '../i18n/I18nProvider';
+import { i18n } from '../i18n';
+import TimelineChart from './TimelineChart';
+
+let lineChartProps: ComponentProps<typeof LineChart> | undefined;
+
+vi.mock('@cloudscape-design/components/line-chart', () => ({
+  default: (props: ComponentProps<typeof LineChart>) => {
+    lineChartProps = props;
+    return <div data-testid="line-chart" />;
+  },
+}));
+
+describe('TimelineChart', () => {
+  beforeEach(() => {
+    lineChartProps = undefined;
+  });
+
+  it.each(['en', 'pt-BR'] as const)(
+    'formats time-axis ticks as concise %s locale dates',
+    async (locale) => {
+      await i18n.changeLanguage(locale);
+
+      render(
+        <I18nProvider>
+          <TimelineChart
+            loading={false}
+            timeline={[
+              {
+                period: '2026-07-19',
+                totalCredits: 10,
+                totalOverageCredits: 2,
+                totalMessages: 3,
+                totalConversations: 1,
+              },
+            ]}
+          />
+        </I18nProvider>,
+      );
+
+      const formatter = lineChartProps?.xTickFormatter;
+      expect(formatter).toBeTypeOf('function');
+
+      const date = new Date('2026-07-19');
+      const label = formatter?.(date);
+      const expected = new Intl.DateTimeFormat(locale, {
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+      }).format(date);
+      const previousDayInBrazil = new Intl.DateTimeFormat('en', {
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'America/Sao_Paulo',
+      }).format(date);
+
+      expect(label).toBe(expected);
+      expect(label).not.toBe(previousDayInBrazil);
+      expect(label).not.toBe(date.toString());
+    },
+  );
+});

--- a/frontend/src/components/TimelineChart.tsx
+++ b/frontend/src/components/TimelineChart.tsx
@@ -11,7 +11,7 @@ interface TimelineChartProps {
 }
 
 export default function TimelineChart({ timeline, loading }: TimelineChartProps) {
-  const { t } = useI18n();
+  const { t, formatDate } = useI18n();
 
   const series = [
     {
@@ -46,6 +46,9 @@ export default function TimelineChart({ timeline, loading }: TimelineChartProps)
           xTitle={t('timeline.axis.period')}
           yTitle={t('timeline.axis.value')}
           xScaleType="time"
+          xTickFormatter={(date) =>
+            formatDate(date, { month: 'short', day: 'numeric', timeZone: 'UTC' })
+          }
           height={300}
           empty={
             <Box textAlign="center" color="inherit">


### PR DESCRIPTION
Closes #21

## Summary

- format timeline X-axis ticks as concise month/day labels in the active UI locale
- preserve calendar dates across user time zones by formatting the API's `YYYY-MM-DD` values in UTC
- add English and Brazilian Portuguese regression coverage
- document the user-visible fix in the changelog

## Root cause

`TimelineChart` supplied `Date` values to Cloudscape without an `xTickFormatter`, so the chart could fall back to the native `Date.toString()` representation, including time and timezone details. Formatting a date-only API value in the browser's local timezone could also move it to the previous day west of UTC.

## Validation

- `vitest --run src/components/TimelineChart.test.tsx` — 2 passed
- frontend suite excluding the pre-existing `localeSwitchIntegration.test.tsx` failures — 23 files, 162 tests passed
- `eslint src/components/TimelineChart.tsx src/components/TimelineChart.test.tsx`
- `tsc -b`
- locale parity check — 686 keys verified
- Vite production build
- local production preview — login page rendered without console warnings/errors; the authenticated timeline route requires Cognito and backend data

The three tests in `localeSwitchIntegration.test.tsx` also fail unchanged on a detached `origin/main` worktree with the same resolved dependencies, so they are unrelated to this patch.
