### PR TITLE
Fix timeline date labels across all charts

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+### Fix — Timeline chart date labels are concise and locale-aware
+
+- Format timeline X-axis ticks as abbreviated month and day values in the active UI locale instead of displaying the native JavaScript `Date.toString()` value with time and timezone details. Calendar-date values are formatted in UTC so users west of UTC do not see the previous day.
+
 ### Security — Second Holmes CSR pass: KMS region scoping, path traversal, log hygiene
 
 Ran a follow-up Holmes CSR scan after the fixes below. Findings and fixes:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -191,7 +191,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -617,7 +616,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -666,7 +664,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -688,7 +685,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -723,6 +719,29 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1502,7 +1521,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1583,7 +1603,6 @@
       "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1594,7 +1613,6 @@
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1605,7 +1623,6 @@
       "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1655,7 +1672,6 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -2057,7 +2073,6 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2111,6 +2126,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2239,7 +2255,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.44",
         "caniuse-lite": "^1.0.30001806",
@@ -2633,7 +2648,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -2701,7 +2717,6 @@
       "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3144,7 +3159,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -3773,6 +3787,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4053,7 +4068,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4106,6 +4120,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4121,6 +4136,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4133,7 +4149,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -4184,7 +4201,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4194,7 +4210,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4597,7 +4612,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4709,7 +4723,6 @@
       "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
@@ -5021,7 +5034,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/ActivityTimelineChart.tsx
+++ b/frontend/src/components/ActivityTimelineChart.tsx
@@ -10,7 +10,7 @@ interface ActivityTimelineChartProps {
 }
 
 export default function ActivityTimelineChart({ timeline, loading }: ActivityTimelineChartProps) {
-  const { t } = useI18n();
+  const { t, formatDate } = useI18n();
 
   const series = [
     {
@@ -51,6 +51,9 @@ export default function ActivityTimelineChart({ timeline, loading }: ActivityTim
           xTitle={t('productivity.activityTimeline.xAxis')}
           yTitle={t('productivity.activityTimeline.yAxis')}
           xScaleType="time"
+          xTickFormatter={(date) =>
+            formatDate(date, { month: 'short', day: 'numeric', timeZone: 'UTC' })
+          }
           height={300}
           empty={<Box textAlign="center" color="inherit">{t('common.empty.noData')}</Box>}
           noMatch={<Box textAlign="center" color="inherit">{t('common.empty.noMatch')}</Box>}

--- a/frontend/src/components/ComparativeTimelineChart.tsx
+++ b/frontend/src/components/ComparativeTimelineChart.tsx
@@ -11,7 +11,7 @@ interface ComparativeTimelineChartProps {
 }
 
 export default function ComparativeTimelineChart({ timeline, loading }: ComparativeTimelineChartProps) {
-  const { t } = useI18n();
+  const { t, formatDate } = useI18n();
 
   const title = t('git.comparativeTimeline.title');
 
@@ -75,6 +75,9 @@ export default function ComparativeTimelineChart({ timeline, loading }: Comparat
         stackedBars
         height={350}
         xScaleType="categorical"
+        xTickFormatter={(date) =>
+          formatDate(date, { month: 'short', day: 'numeric', timeZone: 'UTC' })
+        }
         empty={<Box textAlign="center" color="inherit">{t('common.empty.noData')}</Box>}
         noMatch={<Box textAlign="center" color="inherit">{t('common.empty.noMatch')}</Box>}
         hideFilter={false}

--- a/frontend/src/components/TimelineChart.test.tsx
+++ b/frontend/src/components/TimelineChart.test.tsx
@@ -1,0 +1,66 @@
+import { render } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import LineChart from '@cloudscape-design/components/line-chart';
+import { I18nProvider } from '../i18n/I18nProvider';
+import { i18n } from '../i18n';
+import TimelineChart from './TimelineChart';
+
+let lineChartProps: ComponentProps<typeof LineChart> | undefined;
+
+vi.mock('@cloudscape-design/components/line-chart', () => ({
+  default: (props: ComponentProps<typeof LineChart>) => {
+    lineChartProps = props;
+    return <div data-testid="line-chart" />;
+  },
+}));
+
+describe('TimelineChart', () => {
+  beforeEach(() => {
+    lineChartProps = undefined;
+  });
+
+  it.each(['en', 'pt-BR'] as const)(
+    'formats time-axis ticks as concise %s locale dates',
+    async (locale) => {
+      await i18n.changeLanguage(locale);
+
+      render(
+        <I18nProvider>
+          <TimelineChart
+            loading={false}
+            timeline={[
+              {
+                period: '2026-07-19',
+                totalCredits: 10,
+                totalOverageCredits: 2,
+                totalMessages: 3,
+                totalConversations: 1,
+              },
+            ]}
+          />
+        </I18nProvider>,
+      );
+
+      const formatter = lineChartProps?.xTickFormatter;
+      expect(formatter).toBeTypeOf('function');
+
+      const date = new Date('2026-07-19');
+      const label = formatter?.(date);
+      const expected = new Intl.DateTimeFormat(locale, {
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+      }).format(date);
+      const previousDayInBrazil = new Intl.DateTimeFormat('en', {
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'America/Sao_Paulo',
+      }).format(date);
+
+      expect(label).toBe(expected);
+      expect(label).not.toBe(previousDayInBrazil);
+      expect(label).not.toBe(date.toString());
+    },
+  );
+});

--- a/frontend/src/components/TimelineChart.tsx
+++ b/frontend/src/components/TimelineChart.tsx
@@ -11,7 +11,7 @@ interface TimelineChartProps {
 }
 
 export default function TimelineChart({ timeline, loading }: TimelineChartProps) {
-  const { t } = useI18n();
+  const { t, formatDate } = useI18n();
 
   const series = [
     {
@@ -46,6 +46,9 @@ export default function TimelineChart({ timeline, loading }: TimelineChartProps)
           xTitle={t('timeline.axis.period')}
           yTitle={t('timeline.axis.value')}
           xScaleType="time"
+          xTickFormatter={(date) =>
+            formatDate(date, { month: 'short', day: 'numeric', timeZone: 'UTC' })
+          }
           height={300}
           empty={
             <Box textAlign="center" color="inherit">


### PR DESCRIPTION
## Summary

Formats the X-axis date ticks on **all three** timeline charts as concise, locale-aware `month/day` labels (formatted in UTC to avoid off-by-one day shifts west of UTC), replacing the raw `Date.toString()` output that showed full timestamps with timezone details.

## Charts fixed

- `TimelineChart` — Dashboard / Account Usage (original fix by @breezeFur, issue #21)
- `ActivityTimelineChart` — UserPage "Daily Activity"
- `ComparativeTimelineChart` — Git correlation view

All three now use `formatDate(date, { month: 'short', day: 'numeric', timeZone: 'UTC' })`.

## Credit

This builds directly on the excellent original fix by **@breezeFur** in #21 / #26 — the first commit here (`fix timeline chart date labels`) is theirs, preserved as-is. This PR extends the same clean approach to the two remaining charts that still had the bug. Huge thanks to @breezeFur! 🙏

## Also included

- `chore: sync frontend package-lock.json` — the committed lockfile was out of sync with `package.json` (missing `@emnapi/core`/`@emnapi/runtime`, transitive native deps of Rolldown/Vite 8), which made `npm ci` (used by `make deploy-frontend`) fail with EUSAGE.

## Validation

- Deployed to the live stack (sa-east-1) and visually confirmed all three charts now show `Jul 25`, `6 de ago.` style labels instead of `Sat Jul 25 2026 00:00:00 GMT-0300 (Brasília Standard Time)`.
- `tsc --noEmit` clean on the changed components.

Closes #21