### PR TITLE
Prevent summary card number overflow with compact notation

### DIFF
--- a/.kiro/specs/summary-card-number-overflow/.config.kiro
+++ b/.kiro/specs/summary-card-number-overflow/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "cf49b728-4735-425e-97e5-37cb129ef7e2", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/summary-card-number-overflow/design.md
+++ b/.kiro/specs/summary-card-number-overflow/design.md
@@ -1,0 +1,126 @@
+# Design — Summary Card Number Overflow
+
+## Overview
+
+Fix the mid-number line wrap on KPI cards by (a) abbreviating values ≥ 10,000 with locale-aware compact notation and (b) adding `white-space: nowrap` to value elements. A single shared utility (`formatCardValue`) encapsulates the threshold logic; each component passes its own `formatNumber` (from `useI18n()`), keeping formatting locale-bound.
+
+### Design Decisions
+
+1. **Compact notation over font shrinking**: the issue offers three options (nowrap, responsive font-size, abbreviation). Responsive font sizes fight Cloudscape's typography scale; abbreviation + nowrap fixes the root cause (value wider than the column) at every viewport, and `formatNumber` already passes `Intl.NumberFormatOptions` through, so `notation: 'compact'` works today with zero new dependencies.
+2. **Threshold at 10,000**: values below 10K (e.g. `9,876.54`) fit the 4-column grid and keep full precision, which matters for credits. The reported repro (`10,342.18`) is exactly the first class of values that breaks.
+3. **Helper receives `formatNumber`**: `formatCardValue(value, formatNumber, opts?)` — the utility stays a pure function (unit-testable without React) and never constructs its own `Intl.NumberFormat`, so the active locale is always respected.
+4. **`nowrap` via inline style on the value `Box`**: Cloudscape `Box` accepts nested elements; a `<span style={{ whiteSpace: 'nowrap' }}>` wrapper avoids custom CSS files (per steering §4.2 "do not write custom CSS for components that already exist in Cloudscape" — an inline style on our own span is not a component override).
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant P as Page (Dashboard etc.)
+    participant C as SummaryCards (x5)
+    participant U as formatCardValue (utils)
+    participant F as formatNumber (useI18n)
+
+    P->>C: summary data
+    C->>U: formatCardValue(value, formatNumber)
+    alt |value| >= 10_000
+        U->>F: formatNumber(value, { notation: 'compact', maximumFractionDigits: 1 })
+    else |value| < 10_000
+        U->>F: formatNumber(value, caller opts e.g. 2 fraction digits)
+    end
+    F-->>C: locale-aware string
+    C-->>P: <span nowrap>value</span>
+```
+
+## Components and Interfaces
+
+### 1. formatCardValue utility
+
+**File:** `frontend/src/utils/formatCardValue.ts` (new)
+
+```typescript
+import type { Formatters } from '../i18n/formatters';
+
+export const COMPACT_THRESHOLD = 10_000;
+
+export interface CardValueOptions {
+  /** Fraction digits used below the threshold (default 2, e.g. credits). */
+  fractionDigits?: number;
+}
+
+/**
+ * Formats a KPI card value. At or above COMPACT_THRESHOLD (absolute),
+ * switches to locale-aware compact notation (e.g. 10.3K / 10,3 mil);
+ * below it, keeps standard notation with the given fraction digits.
+ */
+export function formatCardValue(
+  value: number,
+  formatNumber: Formatters['formatNumber'],
+  options?: CardValueOptions,
+): string {
+  const fractionDigits = options?.fractionDigits ?? 2;
+  if (Math.abs(value) >= COMPACT_THRESHOLD) {
+    return formatNumber(value, { notation: 'compact', maximumFractionDigits: 1 });
+  }
+  return formatNumber(value, {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  });
+}
+```
+
+### 2. Component updates (x5)
+
+**Files:** `frontend/src/components/{SummaryCards,AccountSummaryCards,UserSummaryCards,GitSummaryCards,ProductivitySummaryCards}.tsx`
+
+Pattern per component (example from `SummaryCards.tsx`):
+
+```tsx
+const { t, formatNumber } = useI18n();
+const fmt = (n: number) => formatCardValue(n, formatNumber);          // credits: 2-dec below 10K
+const fmtInt = (n: number) => formatCardValue(n, formatNumber, { fractionDigits: 0 }); // counts
+
+// value cell
+<Box variant="awsui-value-large">
+  <span style={{ whiteSpace: 'nowrap' }}>{summary ? fmt(summary.totalCredits) : '—'}</span>
+</Box>
+```
+
+Integer fields currently rendered raw (`totalUsers.toString()`, message/conversation counts) switch to `fmtInt` so they also gain compact + nowrap behavior.
+
+## Data Models
+
+No new models. All summary fields are `number` (`UsageSummary`, `AccountTotals`, `UserDetailSummary`, git/productivity summaries).
+
+## Correctness Properties
+
+*A correctness property is a characteristic or behavior that must hold in all valid executions of a system.*
+
+### Property 1: Threshold split
+
+*For any* finite number `v`, `formatCardValue(v, formatNumber)` SHALL use compact notation if and only if `|v| >= 10_000`; below the threshold the output equals `formatNumber(v, { minimumFractionDigits: d, maximumFractionDigits: d })` for the configured `d`.
+
+**Validates: Requirements 1.1, 1.2**
+
+### Property 2: Locale coherence
+
+*For any* value and any supported locale, the output of `formatCardValue` SHALL equal what `Intl.NumberFormat(locale, <same options>)` produces — i.e. the helper adds no locale-independent formatting of its own.
+
+**Validates: Requirements 1.3**
+
+## Error Handling
+
+| Scenario | Component | Behavior |
+|---|---|---|
+| `summary` undefined (loading) | Summary cards | Existing `'—'` placeholder preserved, helper not called |
+| Non-finite value (NaN/Infinity) | formatCardValue | Delegated to `Intl.NumberFormat` (renders `NaN`/`∞`) — no crash; upstream API contract makes this unreachable |
+
+## Testing Strategy
+
+Property-based (fast-check) + example-based tests for the pure utility; the five components are covered indirectly (helper is the single formatting path).
+
+| Property | Test File | Tag |
+|---|---|---|
+| Property 1: Threshold split | `frontend/src/utils/formatCardValue.test.ts` | Feature: summary-card-number-overflow, Property 1: Threshold split |
+| Property 2: Locale coherence | `frontend/src/utils/formatCardValue.test.ts` | Feature: summary-card-number-overflow, Property 2: Locale coherence |
+
+Example cases: `10342.18 → "10.3K"` (en) / `"10,3 mil"` (pt-BR); `9876.54 → "9,876.54"` (en); `0`, negative values, integer counts with `fractionDigits: 0`.

--- a/.kiro/specs/summary-card-number-overflow/requirements.md
+++ b/.kiro/specs/summary-card-number-overflow/requirements.md
@@ -1,0 +1,43 @@
+# Requirements Document — Summary Card Number Overflow
+
+## Introduction
+
+This document specifies the requirements to fix issue #20 (Design Critique finding F5): large numeric values on summary/KPI cards wrap mid-number to a second line (e.g. "10,342.18" renders as "10,342.1" / "8"), breaking the visual rhythm of the KPI row. The fix applies a compact notation for large values and prevents mid-number line breaks, using the existing locale-aware `formatNumber` helper (which already supports `Intl.NumberFormat`'s `notation: 'compact'`). Five components share the vulnerable pattern: `SummaryCards` (the reported repro), `AccountSummaryCards`, `UserSummaryCards`, `GitSummaryCards`, and `ProductivitySummaryCards`.
+
+## Glossary
+
+- **Summary Card**: A KPI tile rendering a label and a large numeric value, laid out in a multi-column grid (Cloudscape `KeyValuePairs`, `ColumnLayout`, or `Cards`).
+- **Compact Notation**: `Intl.NumberFormat` `notation: 'compact'` output (e.g. `10.3K` in `en`, `10,3 mil` in `pt-BR`).
+- **Threshold**: The absolute value at or above which compact notation is applied (10,000).
+- **formatNumber**: The locale-bound number formatter exposed by `useI18n()` (`frontend/src/i18n/formatters.ts`).
+
+## Requirements
+
+### Requirement 1: Compact rendering of large values
+
+**User Story:** As a user scanning the KPI row, I want large values abbreviated (e.g. 10.3K), so that every value fits on a single line and the row scans cleanly.
+
+#### Acceptance Criteria
+
+1. WHEN a summary card numeric value is greater than or equal to 10,000 in absolute value, THE Summary Card SHALL render it using compact notation with at most 1 fraction digit via `formatNumber`.
+2. WHEN a summary card numeric value is below 10,000 in absolute value, THE Summary Card SHALL keep the existing formatting (2 fraction digits for credit values; integer rendering for counts).
+3. THE compact formatting SHALL be locale-aware, following the active UI locale (e.g. `10.3K` in `en`, `10,3 mil` in `pt-BR`).
+4. THE fix SHALL apply to all five summary-card components: `SummaryCards`, `AccountSummaryCards`, `UserSummaryCards`, `GitSummaryCards`, and `ProductivitySummaryCards`.
+
+### Requirement 2: No mid-number line breaks
+
+**User Story:** As a user, I want numeric values to never wrap across two lines, so that the KPI grid alignment is preserved even in narrow columns.
+
+#### Acceptance Criteria
+
+1. THE Summary Card numeric value SHALL be rendered with `white-space: nowrap` so a value never breaks across lines.
+2. THE label text of the card SHALL keep its default wrapping behavior (labels may wrap; values may not).
+
+### Requirement 3: Shared helper for consistency
+
+**User Story:** As a developer, I want a single shared helper for the threshold-based compact formatting, so that the five components cannot drift apart.
+
+#### Acceptance Criteria
+
+1. THE compact-formatting decision (threshold + options) SHALL live in a single shared utility consumed by all five components.
+2. THE utility SHALL delegate the actual formatting to the `formatNumber` function provided by the caller, preserving locale-awareness and testability.

--- a/.kiro/specs/summary-card-number-overflow/tasks.md
+++ b/.kiro/specs/summary-card-number-overflow/tasks.md
@@ -1,0 +1,39 @@
+# Implementation Plan: Summary Card Number Overflow
+
+## Overview
+
+Frontend-only fix for issue #20: abbreviate large KPI values with locale-aware compact notation and prevent mid-number line wraps, via a shared `formatCardValue` utility applied to all five summary-card components.
+
+## Tasks
+
+- [ ] 1. Create the shared formatting utility
+  - [ ] 1.1 Create `frontend/src/utils/formatCardValue.ts`
+    - `COMPACT_THRESHOLD = 10_000`; compact notation with `maximumFractionDigits: 1` at/above; standard notation with configurable fraction digits below
+    - Pure function receiving `formatNumber` from the caller
+    - _Requirements: 1.1, 1.2, 1.3, 3.1, 3.2_
+  - [ ]* 1.2 Write property tests for the utility
+    - **Property 1: Threshold split** — compact iff `|v| >= 10_000` (fast-check, 100+ runs)
+    - **Property 2: Locale coherence** — output matches `Intl.NumberFormat` with same options for en and pt-BR
+    - Example cases: `10342.18`, `9876.54`, `0`, negatives, integer counts
+    - Create `frontend/src/utils/formatCardValue.test.ts`
+    - **Validates: Requirements 1.1, 1.2, 1.3**
+
+- [ ] 2. Apply the utility and nowrap to all five components
+  - [ ] 2.1 Update `SummaryCards.tsx` (the reported repro)
+    - Replace local `fmt` with `formatCardValue`; wrap values in nowrap span; `totalUsers` via `fractionDigits: 0`
+    - _Requirements: 1.1, 1.4, 2.1, 2.2_
+  - [ ] 2.2 Update `AccountSummaryCards.tsx`, `UserSummaryCards.tsx`, `GitSummaryCards.tsx`, `ProductivitySummaryCards.tsx`
+    - Same pattern; counts use `fractionDigits: 0`, credit values default (2)
+    - _Requirements: 1.4, 2.1, 2.2_
+
+- [ ] 3. Checkpoint — Verify build and tests
+  - Ensure the full build passes (`npm run build`)
+  - Ensure tests pass (vitest)
+  - Deploy to the live stack and ask the user to validate the Dashboard Users tab card
+  - _Requirements: all_
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- Each task references specific requirements for traceability
+- No i18n keys needed — compact suffixes come from `Intl.NumberFormat` itself

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+### Fix — Summary card numbers no longer wrap mid-value
+
+- KPI values at or above 10,000 are abbreviated with locale-aware compact notation (e.g. `10.3K` in en, `10,3 mil` in pt-BR) and all card values render with `white-space: nowrap`, so large numbers no longer break across two lines in the KPI grids. Applied consistently to the Dashboard, Account Usage, User detail, Git activity, and Productivity summary cards via a shared `formatCardValue` utility. Closes #20.
+
 ### Feature — Confirmation modal before deleting a Git repo or mapping
 
 - Deleting a repository or a user-Git mapping on the Git settings page now opens a confirmation modal identifying the target (repository `name` + `url`; mapping `userId` + `gitUsername` + `provider`) instead of firing immediately from the icon button. The modal mirrors the existing `UsersPage` delete-confirmation pattern and is fully internationalized (en + pt-BR). Closes #11.

--- a/frontend/src/components/AccountSummaryCards.tsx
+++ b/frontend/src/components/AccountSummaryCards.tsx
@@ -4,6 +4,7 @@ import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
 import Box from '@cloudscape-design/components/box';
 import { useI18n } from '../i18n/useI18n';
 import SkeletonLoader from './SkeletonLoader';
+import { formatCardValue } from '../utils/formatCardValue';
 import type { AccountTotals } from '../types';
 
 interface AccountSummaryCardsProps {
@@ -11,13 +12,14 @@ interface AccountSummaryCardsProps {
   loading: boolean;
 }
 
+/** Prevents mid-number line wraps inside the KPI grid (issue #20). */
+const nowrap = (content: string) => <span style={{ whiteSpace: 'nowrap' }}>{content}</span>;
+
 export default function AccountSummaryCards({ totals, loading }: AccountSummaryCardsProps) {
   const { t, formatNumber } = useI18n();
 
-  const fmt = (n: number) =>
-    formatNumber(n, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-
-  const fmtInt = (n: number) => formatNumber(n);
+  const fmt = (n: number) => formatCardValue(n, formatNumber);
+  const fmtInt = (n: number) => formatCardValue(n, formatNumber, { fractionDigits: 0 });
 
   if (loading) {
     return <SkeletonLoader variant="cards" count={4} columns={4} />;
@@ -30,19 +32,19 @@ export default function AccountSummaryCards({ totals, loading }: AccountSummaryC
         items={[
           {
             label: t('account.summary.totalCredits'),
-            value: <Box variant="awsui-value-large">{totals ? fmt(totals.totalCredits) : '—'}</Box>,
+            value: <Box variant="awsui-value-large">{totals ? nowrap(fmt(totals.totalCredits)) : '—'}</Box>,
           },
           {
             label: t('account.summary.totalOverage'),
-            value: <Box variant="awsui-value-large">{totals ? fmt(totals.totalOverageCredits) : '—'}</Box>,
+            value: <Box variant="awsui-value-large">{totals ? nowrap(fmt(totals.totalOverageCredits)) : '—'}</Box>,
           },
           {
             label: t('account.summary.totalMessages'),
-            value: <Box variant="awsui-value-large">{totals ? fmtInt(totals.totalMessages) : '—'}</Box>,
+            value: <Box variant="awsui-value-large">{totals ? nowrap(fmtInt(totals.totalMessages)) : '—'}</Box>,
           },
           {
             label: t('account.summary.totalConversations'),
-            value: <Box variant="awsui-value-large">{totals ? fmtInt(totals.totalConversations) : '—'}</Box>,
+            value: <Box variant="awsui-value-large">{totals ? nowrap(fmtInt(totals.totalConversations)) : '—'}</Box>,
           },
         ]}
       />

--- a/frontend/src/components/GitSummaryCards.tsx
+++ b/frontend/src/components/GitSummaryCards.tsx
@@ -3,6 +3,7 @@ import Box from '@cloudscape-design/components/box';
 import Header from '@cloudscape-design/components/header';
 import Spinner from '@cloudscape-design/components/spinner';
 import { useI18n } from '../i18n/useI18n';
+import { formatCardValue } from '../utils/formatCardValue';
 import type { GitActivitySummary } from '../types';
 
 interface GitSummaryCardsProps {
@@ -10,8 +11,14 @@ interface GitSummaryCardsProps {
   loading: boolean;
 }
 
+/** Prevents mid-number line wraps inside the KPI grid (issue #20). */
+const nowrap = (content: string) => <span style={{ whiteSpace: 'nowrap' }}>{content}</span>;
+
 export default function GitSummaryCards({ summary, loading }: GitSummaryCardsProps) {
   const { t, formatNumber } = useI18n();
+
+  const fmtInt = (n: number) => nowrap(formatCardValue(n, formatNumber, { fractionDigits: 0 }));
+  const fmtAvg = (n: number) => nowrap(formatCardValue(n, formatNumber, { fractionDigits: 1 }));
 
   if (loading) {
     return (
@@ -22,12 +29,12 @@ export default function GitSummaryCards({ summary, loading }: GitSummaryCardsPro
   }
 
   const items = [
-    { label: t('git.summary.totalCommits'), value: summary?.totalCommits != null ? formatNumber(summary.totalCommits) : '—' },
-    { label: t('git.summary.totalPRsMerged'), value: summary?.totalPRsMerged != null ? formatNumber(summary.totalPRsMerged) : '—' },
-    { label: t('git.summary.totalReviews'), value: summary?.totalReviews != null ? formatNumber(summary.totalReviews) : '—' },
-    { label: t('git.summary.avgLinesPerCommit'), value: summary?.avgLinesPerCommit != null ? formatNumber(summary.avgLinesPerCommit, { maximumFractionDigits: 1 }) : '—' },
-    { label: t('git.summary.totalPRsOpened'), value: summary?.totalPRsOpened != null ? formatNumber(summary.totalPRsOpened) : '—' },
-    { label: t('git.summary.avgMergeTimeHours'), value: summary?.avgMergeTimeHours != null ? formatNumber(summary.avgMergeTimeHours, { maximumFractionDigits: 1 }) : '—' },
+    { label: t('git.summary.totalCommits'), value: summary?.totalCommits != null ? fmtInt(summary.totalCommits) : '—' },
+    { label: t('git.summary.totalPRsMerged'), value: summary?.totalPRsMerged != null ? fmtInt(summary.totalPRsMerged) : '—' },
+    { label: t('git.summary.totalReviews'), value: summary?.totalReviews != null ? fmtInt(summary.totalReviews) : '—' },
+    { label: t('git.summary.avgLinesPerCommit'), value: summary?.avgLinesPerCommit != null ? fmtAvg(summary.avgLinesPerCommit) : '—' },
+    { label: t('git.summary.totalPRsOpened'), value: summary?.totalPRsOpened != null ? fmtInt(summary.totalPRsOpened) : '—' },
+    { label: t('git.summary.avgMergeTimeHours'), value: summary?.avgMergeTimeHours != null ? fmtAvg(summary.avgMergeTimeHours) : '—' },
   ];
 
   return (

--- a/frontend/src/components/ProductivitySummaryCards.tsx
+++ b/frontend/src/components/ProductivitySummaryCards.tsx
@@ -2,12 +2,16 @@ import Cards from '@cloudscape-design/components/cards';
 import Box from '@cloudscape-design/components/box';
 import Header from '@cloudscape-design/components/header';
 import { useI18n } from '../i18n/useI18n';
+import { formatCardValue } from '../utils/formatCardValue';
 import type { ProductivitySummary } from '../types';
 
 interface ProductivitySummaryCardsProps {
   summary: ProductivitySummary | undefined;
   loading: boolean;
 }
+
+/** Prevents mid-number line wraps inside the KPI grid (issue #20). */
+const nowrap = (content: string) => <span style={{ whiteSpace: 'nowrap' }}>{content}</span>;
 
 function formatHour(hour: number | null | undefined): string {
   if (hour === null || hour === undefined) return '—';
@@ -17,11 +21,14 @@ function formatHour(hour: number | null | undefined): string {
 export default function ProductivitySummaryCards({ summary, loading }: ProductivitySummaryCardsProps) {
   const { t, formatNumber } = useI18n();
 
+  const fmtInt = (n: number) => nowrap(formatCardValue(n, formatNumber, { fractionDigits: 0 }));
+  const fmtAvg = (n: number) => nowrap(formatCardValue(n, formatNumber, { fractionDigits: 1 }));
+
   const items = [
-    { title: t('productivity.summary.totalDaysActive'), value: summary?.totalDaysActive?.toString() ?? '—' },
-    { title: t('productivity.summary.totalInteractions'), value: summary?.totalInteractions != null ? formatNumber(summary.totalInteractions) : '—' },
-    { title: t('productivity.summary.totalPrompts'), value: summary?.totalPrompts != null ? formatNumber(summary.totalPrompts) : '—' },
-    { title: t('productivity.summary.avgDailyInteractions'), value: summary?.avgDailyInteractions != null ? formatNumber(summary.avgDailyInteractions, { minimumFractionDigits: 1 }) : '—' },
+    { title: t('productivity.summary.totalDaysActive'), value: summary?.totalDaysActive != null ? fmtInt(summary.totalDaysActive) : '—' },
+    { title: t('productivity.summary.totalInteractions'), value: summary?.totalInteractions != null ? fmtInt(summary.totalInteractions) : '—' },
+    { title: t('productivity.summary.totalPrompts'), value: summary?.totalPrompts != null ? fmtInt(summary.totalPrompts) : '—' },
+    { title: t('productivity.summary.avgDailyInteractions'), value: summary?.avgDailyInteractions != null ? fmtAvg(summary.avgDailyInteractions) : '—' },
     { title: t('productivity.summary.topCategory'), value: summary?.topCategory || '—' },
     { title: t('productivity.summary.peakHour'), value: formatHour(summary?.peakHour) },
   ];

--- a/frontend/src/components/SummaryCards.tsx
+++ b/frontend/src/components/SummaryCards.tsx
@@ -4,6 +4,7 @@ import KeyValuePairs from '@cloudscape-design/components/key-value-pairs';
 import Box from '@cloudscape-design/components/box';
 import { useI18n } from '../i18n/useI18n';
 import SkeletonLoader from './SkeletonLoader';
+import { formatCardValue } from '../utils/formatCardValue';
 import type { UsageSummary } from '../types';
 
 interface SummaryCardsProps {
@@ -11,11 +12,14 @@ interface SummaryCardsProps {
   loading: boolean;
 }
 
+/** Prevents mid-number line wraps inside the KPI grid (issue #20). */
+const nowrap = (content: string) => <span style={{ whiteSpace: 'nowrap' }}>{content}</span>;
+
 export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
   const { t, formatNumber } = useI18n();
 
-  const fmt = (n: number) =>
-    formatNumber(n, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  const fmt = (n: number) => formatCardValue(n, formatNumber);
+  const fmtInt = (n: number) => formatCardValue(n, formatNumber, { fractionDigits: 0 });
 
   if (loading) {
     return <SkeletonLoader variant="cards" count={4} columns={4} />;
@@ -28,19 +32,19 @@ export default function SummaryCards({ summary, loading }: SummaryCardsProps) {
         items={[
           {
             label: t('dashboard.summary.totalUsers'),
-            value: <Box variant="awsui-value-large">{summary?.totalUsers?.toString() ?? '—'}</Box>,
+            value: <Box variant="awsui-value-large">{summary ? nowrap(fmtInt(summary.totalUsers)) : '—'}</Box>,
           },
           {
             label: t('dashboard.summary.totalCredits'),
-            value: <Box variant="awsui-value-large">{summary ? fmt(summary.totalCredits) : '—'}</Box>,
+            value: <Box variant="awsui-value-large">{summary ? nowrap(fmt(summary.totalCredits)) : '—'}</Box>,
           },
           {
             label: t('dashboard.summary.totalOverage'),
-            value: <Box variant="awsui-value-large">{summary ? fmt(summary.totalOverageCredits) : '—'}</Box>,
+            value: <Box variant="awsui-value-large">{summary ? nowrap(fmt(summary.totalOverageCredits)) : '—'}</Box>,
           },
           {
             label: t('dashboard.summary.averagePerUser'),
-            value: <Box variant="awsui-value-large">{summary ? fmt(summary.averageCreditsPerUser) : '—'}</Box>,
+            value: <Box variant="awsui-value-large">{summary ? nowrap(fmt(summary.averageCreditsPerUser)) : '—'}</Box>,
           },
         ]}
       />

--- a/frontend/src/components/UserSummaryCards.tsx
+++ b/frontend/src/components/UserSummaryCards.tsx
@@ -3,6 +3,7 @@ import Box from '@cloudscape-design/components/box';
 import Container from '@cloudscape-design/components/container';
 import Header from '@cloudscape-design/components/header';
 import { useI18n } from '../i18n/useI18n';
+import { formatCardValue } from '../utils/formatCardValue';
 import type { UserDetailSummary } from '../types';
 
 interface UserSummaryCardsProps {
@@ -10,13 +11,14 @@ interface UserSummaryCardsProps {
   loading: boolean;
 }
 
+/** Prevents mid-number line wraps inside the KPI grid (issue #20). */
+const nowrap = (content: string) => <span style={{ whiteSpace: 'nowrap' }}>{content}</span>;
+
 export default function UserSummaryCards({ summary, loading }: UserSummaryCardsProps) {
   const { t, formatNumber } = useI18n();
 
-  const fmt = (n: number) =>
-    formatNumber(n, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-
-  const fmtInt = (n: number) => formatNumber(n);
+  const fmt = (n: number) => nowrap(formatCardValue(n, formatNumber));
+  const fmtInt = (n: number) => nowrap(formatCardValue(n, formatNumber, { fractionDigits: 0 }));
 
   if (loading) {
     return (

--- a/frontend/src/utils/formatCardValue.test.ts
+++ b/frontend/src/utils/formatCardValue.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for formatCardValue (issue #20 — summary card number overflow).
+ *
+ * Feature: summary-card-number-overflow, Property 1: Threshold split
+ * Feature: summary-card-number-overflow, Property 2: Locale coherence
+ */
+
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+import { createFormatters } from '../i18n/formatters';
+import { COMPACT_THRESHOLD, formatCardValue } from './formatCardValue';
+
+const en = createFormatters('en');
+const ptBR = createFormatters('pt-BR');
+
+describe('formatCardValue', () => {
+  // Feature: summary-card-number-overflow, Property 1: Threshold split
+  it('uses compact notation iff |value| >= threshold (property, en)', () => {
+    fc.assert(
+      fc.property(
+        fc.double({ min: -1e12, max: 1e12, noNaN: true, noDefaultInfinity: true }),
+        (value) => {
+          const output = formatCardValue(value, en.formatNumber);
+          const expected =
+            Math.abs(value) >= COMPACT_THRESHOLD
+              ? en.formatNumber(value, { notation: 'compact', maximumFractionDigits: 1 })
+              : en.formatNumber(value, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+          expect(output).toBe(expected);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  // Feature: summary-card-number-overflow, Property 2: Locale coherence
+  it('matches Intl.NumberFormat output for both locales (property)', () => {
+    fc.assert(
+      fc.property(
+        fc.double({ min: 0, max: 1e9, noNaN: true, noDefaultInfinity: true }),
+        (value) => {
+          for (const [locale, fmts] of [['en', en], ['pt-BR', ptBR]] as const) {
+            const output = formatCardValue(value, fmts.formatNumber);
+            const options: Intl.NumberFormatOptions =
+              Math.abs(value) >= COMPACT_THRESHOLD
+                ? { notation: 'compact', maximumFractionDigits: 1 }
+                : { minimumFractionDigits: 2, maximumFractionDigits: 2 };
+            expect(output).toBe(new Intl.NumberFormat(locale, options).format(value));
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('abbreviates the reported repro value 10342.18 (en)', () => {
+    expect(formatCardValue(10342.18, en.formatNumber)).toBe('10.3K');
+  });
+
+  it('abbreviates the reported repro value 10342.18 (pt-BR)', () => {
+    expect(formatCardValue(10342.18, ptBR.formatNumber)).toBe(
+      new Intl.NumberFormat('pt-BR', { notation: 'compact', maximumFractionDigits: 1 }).format(10342.18),
+    );
+  });
+
+  it('keeps 2-decimal formatting below the threshold (en)', () => {
+    expect(formatCardValue(9876.54, en.formatNumber)).toBe('9,876.54');
+  });
+
+  it('renders integer counts without decimals below the threshold', () => {
+    expect(formatCardValue(42, en.formatNumber, { fractionDigits: 0 })).toBe('42');
+  });
+
+  it('handles zero', () => {
+    expect(formatCardValue(0, en.formatNumber)).toBe('0.00');
+  });
+
+  it('compacts large negative values', () => {
+    expect(formatCardValue(-25000, en.formatNumber)).toBe('-25K');
+  });
+});

--- a/frontend/src/utils/formatCardValue.ts
+++ b/frontend/src/utils/formatCardValue.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared KPI/summary-card value formatting.
+ *
+ * Large values wrapped mid-number inside the 4-column KPI grids
+ * (issue #20 / design critique F5). At or above COMPACT_THRESHOLD the
+ * value switches to locale-aware compact notation (e.g. "10.3K" in en,
+ * "10,3 mil" in pt-BR) so it always fits on one line; below the
+ * threshold the standard notation with full precision is preserved.
+ *
+ * The caller provides `formatNumber` from `useI18n()`, keeping this a
+ * pure, locale-agnostic function: all locale behavior lives in the
+ * provided formatter.
+ */
+
+import type { Formatters } from '../i18n/formatters';
+
+/** Absolute value at/above which compact notation is applied. */
+export const COMPACT_THRESHOLD = 10_000;
+
+export interface CardValueOptions {
+  /** Fraction digits used below the threshold (default 2, e.g. credits). */
+  fractionDigits?: number;
+}
+
+/**
+ * Formats a KPI card value. At or above COMPACT_THRESHOLD (absolute),
+ * uses compact notation with at most 1 fraction digit; below it, uses
+ * standard notation with the configured fraction digits.
+ */
+export function formatCardValue(
+  value: number,
+  formatNumber: Formatters['formatNumber'],
+  options?: CardValueOptions,
+): string {
+  const fractionDigits = options?.fractionDigits ?? 2;
+  if (Math.abs(value) >= COMPACT_THRESHOLD) {
+    return formatNumber(value, { notation: 'compact', maximumFractionDigits: 1 });
+  }
+  return formatNumber(value, {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the mid-number line wrap on KPI cards (finding F5 from the design critique #15): values like `10,342.18` broke into two lines in the 4-column grid.

## Changes

- New shared `formatCardValue` utility: values >= 10,000 (absolute) switch to locale-aware compact notation (`10.3K` en / `10,3 mil` pt-BR, via the existing `formatNumber` — `Intl.NumberFormat` `notation: 'compact'`); below the threshold, existing precision is preserved (2-dec credits, integer counts).
- All card values wrapped in `white-space: nowrap` so a value can never break across lines.
- Applied consistently to all five summary-card components: `SummaryCards`, `AccountSummaryCards`, `UserSummaryCards`, `GitSummaryCards`, `ProductivitySummaryCards`.
- Property-based tests (fast-check, 100 runs) for the threshold split and locale coherence, plus example cases including the reported `10,342.18` repro.
- Spec under `.kiro/specs/summary-card-number-overflow/`.

## Validation

- `formatCardValue.test.ts` — 8/8 passing
- Full frontend build (`check:locales && tsc -b && vite build`) — passing

Closes #20