### PR TITLE
Promote changelog to v3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ End-to-end patterns you can lift into your own work:
 
 This sample was built end-to-end with [Kiro](https://kiro.dev) using a spec-driven development flow. The codebase, infrastructure, i18n catalogs, threat model, and most of the prose in this README and `docs/` were produced in collaboration with Kiro.
 
-The repository contains roughly **20 specs** under [`.kiro/specs/`](.kiro/specs/), each composed of `requirements.md` (user stories with `SHALL/WHEN/THEN` acceptance criteria), `design.md` (components, interfaces, data models, correctness properties), and `tasks.md` (an implementation plan back-traceable to requirements). Codebase conventions live in [`.kiro/steering/development-standards.md`](.kiro/steering/development-standards.md) so Kiro applies them consistently across sessions and contributors.
+The repository contains roughly **25 specs** under [`.kiro/specs/`](.kiro/specs/), each composed of `requirements.md` (user stories with `SHALL/WHEN/THEN` acceptance criteria), `design.md` (components, interfaces, data models, correctness properties), and `tasks.md` (an implementation plan back-traceable to requirements). Codebase conventions live in [`.kiro/steering/development-standards.md`](.kiro/steering/development-standards.md) so Kiro applies them consistently across sessions and contributors.
 
 To extend or contribute using Kiro, [CONTRIBUTING.md](CONTRIBUTING.md#using-kiro-when-contributing) explains what fits a spec, what fits a vibe-coding session, and what to keep out of the agent loop.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,7 @@
 
 > Back to [README](../README.md)
 
-## Unreleased
+## v3.4 — Git Settings Usability, UI Fixes & Security Hardening (2026-08-17)
 
 ### Feature — Edit a Git repo and rotate its access token in place
 


### PR DESCRIPTION
Promotes the `Unreleased` changelog section to **v3.4 — Git Settings Usability, UI Fixes & Security Hardening (2026-08-17)**.

Covers this release cycle:
- Git repo edit + in-place token rotation (#13 / PR #30)
- Summary card number overflow fix (#20 / PR #29)
- Git settings delete confirmation modals (#11 / PR #28)
- Timeline chart date labels (#21 / PR #27)
- Plus the three security entries that were already in Unreleased (Holmes CSR pass, source-bucket hot-swap removal, react-router 8.3.0 migration)

Also syncs the README spec count (roughly 20 → roughly 25; `.kiro/specs/` now has 26) per steering §8.5.

Documentation-only change.