### PR TITLE
ci: set git identity before creating the release tag

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -43,6 +43,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "v$VERSION" -m "Release v$VERSION"
           git push origin "v$VERSION"
           gh release create "v$VERSION" --title "v$VERSION" --notes-file /tmp/release-notes.md


### PR DESCRIPTION
Fixes the first run of `publish-release.yml` (run 32083811173), which failed with `fatal: empty ident name` — `git tag -a` requires a committer identity on the runner. Sets the standard github-actions bot identity before tagging.

After merge, the workflow will re-trigger only on the next VERSION change; for the pending v3.4 tag I will re-run it manually via workflow re-run (the VERSION file is already on main).