### PR TITLE
fix(tests): stop Property 13 collapsing duplicate repoIds

### DIFF
--- a/tests/test_agent_main.py
+++ b/tests/test_agent_main.py
@@ -198,6 +198,38 @@ class TestHandlerReturnsValidJsonProperty:
 class TestNormalizeDescriptors:
     """Unit tests for `_normalize_descriptors`'s DD-5 default/drop behavior."""
 
+    def test_duplicate_repo_ids_both_survive(self):
+        """The function does not de-duplicate: it appends every descriptor
+        that survives defaulting and the drop conditions.
+
+        Pinned deterministically because a property test used to index the
+        output by repoId, which collapsed two entries sharing one repoId and
+        produced a false failure. In production repoId is a per-repository
+        uuid4 slice so collisions do not occur, but this function is
+        documented as tolerant of whatever an older backend build sends, so
+        the behaviour is asserted rather than assumed.
+        """
+        repos = [
+            {
+                "repoId": "aaaaaaaa",
+                "provider": "github",
+                "owner": "acme",
+                "repo": "billing",
+                "gitUsername": "alice",
+            },
+            {
+                "repoId": "aaaaaaaa",
+                "provider": "github",
+                "owner": "acme",
+                "repo": "invoicing",
+                "gitUsername": "alice",
+            },
+        ]
+        result = _normalize_descriptors(repos, fallback_username="")
+
+        assert len(result) == 2
+        assert [entry["repo"] for entry in result] == ["billing", "invoicing"]
+
     def test_missing_provider_defaults_to_github(self):
         repos = [{"repoId": "aaaaaaaa", "owner": "acme", "repo": "billing", "gitUsername": "alice"}]
         result = _normalize_descriptors(repos, fallback_username="")

--- a/tests/test_gitlab_provider_properties.py
+++ b/tests/test_gitlab_provider_properties.py
@@ -2799,23 +2799,33 @@ class TestProperty13ProviderDispatchTotality:
             and entry.get("gitUsername")
         ]
 
-        result_by_repo_id = {
-            entry.get("repoId"): entry for entry in result if entry.get("repoId") is not None
-        }
+        # Deliberately NOT indexed by repoId. `_normalize_descriptors` does
+        # not de-duplicate — it appends every surviving descriptor — so two
+        # input entries may legitimately share a repoId. A dict keyed by
+        # repoId would keep only the last of them and then compare the
+        # first input against the wrong output entry. In production repoId
+        # is a per-repository uuid4 slice and collisions do not occur, but
+        # this function is documented as tolerant of whatever an older
+        # backend build sends, so the property must not depend on it.
+        surviving_identities = [
+            (
+                _p13_identifying_fields(entry),
+                entry.get("gitUsername"),
+            )
+            for entry in result
+        ]
 
         for input_entry in already_valid_inputs:
-            repo_id = input_entry.get("repoId")
-            assert repo_id in result_by_repo_id, (
-                "An already-valid input descriptor was dropped by "
+            expected = (
+                _p13_identifying_fields(input_entry),
+                # gitUsername was already non-empty, so it must not have
+                # been overridden by the fallback.
+                input_entry["gitUsername"],
+            )
+            assert expected in surviving_identities, (
+                "An already-valid input descriptor was dropped or altered by "
                 "normalization: %r" % (input_entry,)
             )
-            output_entry = result_by_repo_id[repo_id]
-            expected = _p13_identifying_fields(input_entry)
-            for key, value in expected.items():
-                assert output_entry[key] == value
-            # gitUsername was already non-empty, so it must not have been
-            # overridden by the fallback.
-            assert output_entry["gitUsername"] == input_entry["gitUsername"]
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Closes #47.

## The failure

```
AssertionError: assert '0' == '00'
repos=[
  {'repoId': '00000000', 'provider': 'github', 'gitUsername': '0', 'owner': '0', 'repo': '00'},
  {'repoId': '00000000', 'provider': 'github', 'owner': '0', 'repo': '0'},
]
```

## The defect is in the test

The property indexed the output by `repoId`:

```python
result_by_repo_id = {entry.get("repoId"): entry for entry in result if ...}
```

With two entries sharing a `repoId` that keeps only the last, so the first input was compared against the wrong output entry.

`_normalize_descriptors` does **not** de-duplicate — it appends every descriptor surviving defaulting and the drop conditions — so duplicate `repoId`s are legal input. Keying by `repoId` silently added an assumption the function never promises. In production `repoId` is a per-repository `uuid4().hex[:8]` and collisions do not occur, but the function is explicitly documented as tolerant of whatever an older backend build sends, so the property must not depend on it.

## Fix

The assertion now checks that each already-valid input's identifying fields **plus** its `gitUsername` appear among the surviving entries — the property actually intended, and true regardless of `repoId` uniqueness.

Also adds a deterministic regression test in `TestNormalizeDescriptors` so this no longer depends on Hypothesis rediscovering the case (the example only reproduces once it is in the local Hypothesis database, which is why it can appear to surface spontaneously).

## Verification

Test-only — no runtime behaviour changes, so no deploy is required. Full Python suite: **949 passed, zero failures**.