### PR TITLE
feat: refresh button on the ETL execution history table

### DIFF
--- a/frontend/src/components/EtlExecutionHistory.tsx
+++ b/frontend/src/components/EtlExecutionHistory.tsx
@@ -2,6 +2,7 @@ import Table from '@cloudscape-design/components/table';
 import Container from '@cloudscape-design/components/container';
 import Header from '@cloudscape-design/components/header';
 import Box from '@cloudscape-design/components/box';
+import Button from '@cloudscape-design/components/button';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
 import Alert from '@cloudscape-design/components/alert';
 import { useI18n } from '../i18n/useI18n';
@@ -18,6 +19,7 @@ interface EtlExecutionHistoryProps {
   loading: boolean;
   error: string | null;
   days: number;
+  onRefresh: () => void;
 }
 
 /**
@@ -34,6 +36,7 @@ export default function EtlExecutionHistory({
   loading,
   error,
   days,
+  onRefresh,
 }: EtlExecutionHistoryProps) {
   const { t, formatDateTime, formatNumber } = useI18n();
 
@@ -45,7 +48,18 @@ export default function EtlExecutionHistory({
   return (
     <Container
       header={
-        <Header variant="h2" description={t('settings.etl.history.description', { days })}>
+        <Header
+          variant="h2"
+          description={t('settings.etl.history.description', { days })}
+          actions={
+            <Button
+              iconName="refresh"
+              ariaLabel={t('common.refresh')}
+              onClick={onRefresh}
+              loading={loading}
+            />
+          }
+        >
           {t('settings.etl.history.title')}
         </Header>
       }

--- a/frontend/src/components/__tests__/EtlExecutionHistory.test.tsx
+++ b/frontend/src/components/__tests__/EtlExecutionHistory.test.tsx
@@ -21,8 +21,8 @@
  * Validates Requirements 4.2, 4.5, 4.6, 4.7, 4.8.
  */
 
-import { render, screen, within } from '@testing-library/react';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import fc from 'fast-check';
 import type { ReactNode } from 'react';
 import { I18nProvider } from '../../i18n/I18nProvider';
@@ -78,6 +78,7 @@ function renderHistory(overrides: Partial<Parameters<typeof EtlExecutionHistory>
         loading={false}
         error={null}
         days={5}
+        onRefresh={() => {}}
         {...overrides}
       />
     </Harness>,
@@ -162,6 +163,25 @@ describe('EtlExecutionHistory', () => {
       executions: [{ ...SUCCEEDED, status: 'PENDING_REDRIVE' }],
     });
     expect(screen.getByText('PENDING_REDRIVE')).toBeInTheDocument();
+  });
+
+  it('calls onRefresh when the refresh button is clicked', () => {
+    const onRefresh = vi.fn();
+    renderHistory({ executions: [SUCCEEDED], onRefresh });
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the refresh button as loading while the history is being fetched', () => {
+    const onRefresh = vi.fn();
+    renderHistory({ loading: true, onRefresh });
+    // Cloudscape marks a loading button with aria-disabled rather than the HTML
+    // disabled attribute, so it stays focusable while refusing activation — a
+    // second click during an in-flight fetch cannot fire another request.
+    const button = screen.getByRole('button', { name: 'Refresh' });
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    fireEvent.click(button);
+    expect(onRefresh).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -295,6 +295,7 @@ export default function SettingsPage() {
         loading={executionsLoading}
         error={executionsError}
         days={ETL_HISTORY_DAYS}
+        onRefresh={fetchExecutions}
       />
     </SpaceBetween>
   );


### PR DESCRIPTION
## Summary

Adds a Cloudscape icon-only refresh button to the top-right of the ETL execution history table, in the container header's `actions` slot.

The table shows a pipeline that changes without the user doing anything — the nightly schedule fires, or a run is started from the button in the card above. Re-reading it required a full page reload, which also re-fetched the config. This wires the header action to `fetchExecutions`, the same call the tab already makes on mount.

## Behaviour while fetching

The button carries `loading={loading}`. Cloudscape renders that as `aria-disabled` rather than the HTML `disabled` attribute, so the button stays focusable — correct for keyboard and screen-reader users — while refusing activation. An impatient second click during an in-flight request cannot fire a duplicate.

## i18n

Reuses the existing `common.refresh` key as the `ariaLabel` (the button is icon-only, so it needs an accessible name). No new catalog keys, so key parity is untouched.

## Testing

**188 frontend tests** (+2): the click calls `onRefresh` exactly once, and a click while loading does not call it at all.

`npm run build` (including `check:locales`) passes; the two changed files are lint-clean.

Deployed to the stack via `make deploy-frontend AWS_PROFILE=kca` — frontend-only change, so no infra deploy.
