### PR TITLE
chore: ignore the Python virtualenv the agent deploy expects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 node_modules/
 frontend/node_modules/
 
+# Python virtualenv. `make deploy-agentcore` requires the agentcore CLI in an
+# active venv and its preflight names `.venv` in the project root, so the
+# documented setup step would otherwise leave the working tree dirty.
+.venv/
+venv/
+
 # Build artifacts
 .aws-sam/
 frontend/dist/


### PR DESCRIPTION
`check-agentcore-env` requires the `agentcore` CLI inside an **active** virtualenv, and its failure message instructs:

```
python3 -m venv .venv
source .venv/bin/activate
pip install bedrock-agentcore-starter-toolkit==0.3.11
```

Neither `.venv/` nor `venv/` was ignored, so following the project's own documented setup step left the working tree dirty — and made committing a virtualenv a real possibility. Adds both under **Dependencies**, next to `node_modules/`, since a venv is the Python equivalent of that directory.

Worth noting for anyone hitting the same wall: on Debian/Ubuntu that `python3 -m venv` command fails outright until `python3.13-venv` is installed, because the distro ships `ensurepip` in a separate package. That is a host prerequisite, not a repo issue, so it is not changed here — but it is the reason a developer may end up putting the venv outside the project instead.

No changelog entry: this is dev-tooling hygiene with no runtime, build, or deploy behaviour change, and the changelog feeds the published release notes.